### PR TITLE
Prevent mute button from falling off screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -25,6 +25,7 @@
 
 livery-player {
   width: 70%;
+  min-width: 0;
   object-fit: contain;
   z-index: 999;
   justify-self: flex-start;


### PR DESCRIPTION
Fixed by setting min-width of the video player element to 0 rather than the default 'auto' so that it would shrink to its containing div rather than expanding its boundaries off the screen.